### PR TITLE
Implement install and uninstall targets in non-dkms Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,3 +14,15 @@ clean:
 load:
 	-/sbin/rmmod $(modname)
 	/sbin/insmod $(modname).ko
+
+install:
+	mkdir -p /lib/modules/$(KVERSION)/misc/$(modname)
+	install -m 0755 -o root -g root $(modname).ko /lib/modules/$(KVERSION)/misc/$(modname)
+	depmod -a
+	modprobe $(modname)
+
+uninstall:
+	rm /lib/modules/$(KVERSION)/misc/$(modname)/$(modname).ko
+	rmdir /lib/modules/$(KVERSION)/misc/$(modname)
+	rmdir /lib/modules/$(KVERSION)/misc
+	depmod -a


### PR DESCRIPTION
For if you do not want to or are unable to use dkms; targets are very simple and rudimentary, yet work fine on my F17 box
