### PR TITLE
Add install and uninstall targets to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,3 +14,14 @@ clean:
 load:
 	-/sbin/rmmod $(modname)
 	/sbin/insmod $(modname).ko
+
+install:
+	mkdir -p /lib/modules/$(KVERSION)/misc/$(modname)
+	install -m 0755 -o root -g root $(modname).ko /lib/modules/$(KVERSION)/misc/$(modname)
+	depmod -a
+
+uninstall:
+	rm /lib/modules/$(KVERSION)/misc/$(modname)/$(modname).ko
+	rmdir /lib/modules/$(KVERSION)/misc/$(modname)
+	rmdir /lib/modules/$(KVERSION)/misc
+	depmod -a


### PR DESCRIPTION
For if you do not want to or are unable to use dkms

Develop -> develop now, and without the modprobe command in the 'install' target.
