### PR TITLE
Change DEVICE_ACPI_HANDLE to ACPI_HANDLE for linux-3.13

### DIFF
--- a/bbswitch.c
+++ b/bbswitch.c
@@ -35,6 +35,7 @@
 #include <linux/suspend.h>
 #include <linux/seq_file.h>
 #include <linux/pm_runtime.h>
+#include <linux/version.h>
 
 #define BBSWITCH_VERSION "0.7"
 
@@ -400,7 +401,11 @@ static int __init bbswitch_init(void) {
             pci_class != PCI_CLASS_DISPLAY_3D)
             continue;
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 13, 0)
+        handle = ACPI_HANDLE(&pdev->dev);
+#else
         handle = DEVICE_ACPI_HANDLE(&pdev->dev);
+#endif
         if (!handle) {
             pr_warn("cannot find ACPI handle for VGA device %s\n",
                 dev_name(&pdev->dev));


### PR DESCRIPTION
The commit 3a83f992490f8235661b768e53bd5f14915420ac
"ACPI: Eliminate the DEVICE_ACPI_HANDLE() macro" from mainline removes
DEVICE_ACPI_HANDLE in favor of ACPI_HANDLE.

This patch makes bbswitch to use ACPI_HANDLE when linux version is greater
than 3.13 in order to be built properly.

Signed-off-by: Chunwei Chen tuxoko@gmail.com
