### PR TITLE
Change DEVICE_ACPI_HANDLE to ACPI_HANDLE for linux-3.13

### DIFF
--- a/bbswitch.c
+++ b/bbswitch.c
@@ -400,7 +400,12 @@ static int __init bbswitch_init(void) {
             pci_class != PCI_CLASS_DISPLAY_3D)
             continue;
 
+#ifdef ACPI_HANDLE
+	/* for linux-3.8 and later */
+        handle = ACPI_HANDLE(&pdev->dev);
+#else
         handle = DEVICE_ACPI_HANDLE(&pdev->dev);
+#endif
         if (!handle) {
             pr_warn("cannot find ACPI handle for VGA device %s\n",
                 dev_name(&pdev->dev));


### PR DESCRIPTION
The commit 3a83f992490f8235661b768e53bd5f14915420ac
"ACPI: Eliminate the DEVICE_ACPI_HANDLE() macro" from mainline removes
DEVICE_ACPI_HANDLE in favor of ACPI_HANDLE.

This patch makes bbswitch to use ACPI_HANDLE when available in order to
be built properly.

Signed-off-by: Chunwei Chen tuxoko@gmail.com
