### PR TITLE
Include command "dkms add" in Makefile

### DIFF
--- a/Makefile.dkms
+++ b/Makefile.dkms
@@ -12,7 +12,10 @@ src_install:
 	cp Makefile bbswitch.c '$(DKMS_DEST)'
 	sed 's/#MODULE_VERSION#/$(modver)/' dkms/dkms.conf > '$(DKMS_DEST)/dkms.conf'
 
-build: src_install
+add: src_install
+	$(DKMS) add -m bbswitch -v $(modver)
+
+build: add
 	$(DKMS) build -m bbswitch -v $(modver)
 
 install: build
@@ -21,4 +24,4 @@ install: build
 uninstall:
 	$(DKMS) remove -m bbswitch -v $(modver) --all
 
-.PHONY: all src_install build install uninstall
+.PHONY: all src_install add build install uninstall


### PR DESCRIPTION
DKMS was complaining about missing module in tree:
**Error! DKMS tree does not contain: bbswitch-0.8**
This adds the _dkms add_ command that makes everything smooth on my machine (using dkms 2.0.19).
Suggesting this in case other people run into the same issue - I suspect it depends on the dkms version, but I'm not sure.
