### PR TITLE
Why not set the version?

### DIFF
--- a/dkms/dkms.conf
+++ b/dkms/dkms.conf
@@ -1,5 +1,5 @@
 PACKAGE_NAME="bbswitch"
-PACKAGE_VERSION="#MODULE_VERSION#"
+PACKAGE_VERSION="0.8.0"
 MAKE[0]="make KVERSION=$kernelver"
 CLEAN="make clean"
 BUILT_MODULE_NAME[0]="bbswitch"


### PR DESCRIPTION
Currently it cannot work correctly if the user tries to add it to dkms without changing the package version. DKMS will add it with "#MODULE_VERSION#" as the version number but it will fail to compile.