### PR TITLE
Fix bbswitch_fops struct for kernels > 5.6.15

### DIFF
--- a/bbswitch.c
+++ b/bbswitch.c
@@ -380,19 +380,19 @@ static int bbswitch_pm_handler(struct notifier_block *nbp,
 // This struct change was introduced in 5.6.16 - STABLE
 // see: https://lore.kernel.org/lkml/20191225172546.GB13378@avx2/
 static struct proc_ops bbswitch_pops = {
-    .proc_open   = bbswitch_proc_open,
-    .proc_read   = seq_read,
-    .proc_write  = bbswitch_proc_write,
-    .proc_lseek = seq_lseek,
-    .proc_release= single_release
+    .proc_open    = bbswitch_proc_open,
+    .proc_read    = seq_read,
+    .proc_write   = bbswitch_proc_write,
+    .proc_lseek   = seq_lseek,
+    .proc_release = single_release
 };
 #else
 static struct file_operations bbswitch_pops = {
-    .open   = bbswitch_proc_open,
-    .read   = seq_read,
-    .write  = bbswitch_proc_write,
-    .llseek = seq_lseek,
-    .release= single_release
+    .open    = bbswitch_proc_open,
+    .read    = seq_read,
+    .write   = bbswitch_proc_write,
+    .llseek  = seq_lseek,
+    .release = single_release
 };
 #endif
 


### PR DESCRIPTION
The kernel guys changed the guts on this struct in 5.6.16 - stable.
The change has also been merged into mainline kernel 5.7.

See: https://lore.kernel.org/lkml/20191225172546.GB13378@avx2/

Signed-off-by: Johnathan Botha <jokillsya@gmail.com>