### PR TITLE
Removed warnings that cause make to fail

### DIFF
--- a/bbswitch.c
+++ b/bbswitch.c
@@ -460,7 +460,7 @@ static int __init bbswitch_init(void) {
         }
     }
 
-    acpi_entry = proc_create("bbswitch", 0664, acpi_root_dir, &bbswitch_fops);
+    acpi_entry = proc_create("bbswitch", 0664, acpi_root_dir, (const struct proc_ops *) &bbswitch_fops);
     if (acpi_entry == NULL) {
         pr_err("Couldn't create proc entry\n");
         return -ENOMEM;

--- a/bbswitch.c
+++ b/bbswitch.c
@@ -35,6 +35,9 @@
 #include <linux/suspend.h>
 #include <linux/seq_file.h>
 #include <linux/pm_runtime.h>
+#include <linux/pm_runtime.h>
+#include <linux/proc_fs.h>
+
 
 #define BBSWITCH_VERSION "0.8"
 
@@ -76,7 +79,7 @@ The next UUID has been found as well in
 https://bugs.launchpad.net/lpbugreporter/+bug/752542:
 
 0xD3, 0x73, 0xD8, 0x7E, 0xD0, 0xC2, 0x4F, 0x4E,
-0xA8, 0x54, 0x0F, 0x13, 0x17, 0xB0, 0x1C, 0x2C 
+0xA8, 0x54, 0x0F, 0x13, 0x17, 0xB0, 0x1C, 0x2C
 It looks like something for Intel GPU:
 http://lxr.linux.no/#linux+v3.1.5/drivers/gpu/drm/i915/intel_acpi.c
  */


### PR DESCRIPTION
Initially, because `proc_create' and `remove_proc_entry` are implicitly declared, the following errors show
```
make -C /lib/modules/5.9.14-arch1-1/build M="$(pwd)" modules
make[1]: Entering directory '/usr/lib/modules/5.9.14-arch1-1/build'
  CC [M]  /home/nicklaus/Repositories/bbswitch/bbswitch.o
/home/nicklaus/Repositories/bbswitch/bbswitch.c: In function ‘bbswitch_init’:
/home/nicklaus/Repositories/bbswitch/bbswitch.c:460:18: error: implicit declaration of function ‘proc_create’ [-Werror=implicit-function-declaration]
  460 |     acpi_entry = proc_create("bbswitch", 0664, acpi_root_dir, &bbswitch_fops);
      |                  ^~~~~~~~~~~
/home/nicklaus/Repositories/bbswitch/bbswitch.c:460:16: warning: assignment to ‘struct proc_dir_entry *’ from ‘int’ makes pointer from integer without a cast [-Wint-conversion]
  460 |     acpi_entry = proc_create("bbswitch", 0664, acpi_root_dir, &bbswitch_fops);
      |                ^
/home/nicklaus/Repositories/bbswitch/bbswitch.c: In function ‘bbswitch_exit’:
/home/nicklaus/Repositories/bbswitch/bbswitch.c:490:5: error: implicit declaration of function ‘remove_proc_entry’ [-Werror=implicit-function-declaration]
  490 |     remove_proc_entry("bbswitch", acpi_root_dir);
      |     ^~~~~~~~~~~~~~~~~
cc1: some warnings being treated as errors
make[2]: *** [scripts/Makefile.build:283: /home/nicklaus/Repositories/bbswitch/bbswitch.o] Error 1
make[1]: *** [Makefile:1784: /home/nicklaus/Repositories/bbswitch] Error 2
make[1]: Leaving directory '/usr/lib/modules/5.9.14-arch1-1/build'
make: *** [Makefile:13: default] Error 2
```

This PR seeks to resolve these errors