### PR TITLE
check for power state only on x86 and arm64

### DIFF
--- a/bbswitch.c
+++ b/bbswitch.c
@@ -260,6 +260,7 @@ static void bbswitch_off(void) {
     pci_save_state(dis_dev);
     pci_clear_master(dis_dev);
     pci_disable_device(dis_dev);
+#ifdef CONFIG_ACPI
     do {
         struct acpi_device *ad = NULL;
         int r;
@@ -274,6 +275,7 @@ static void bbswitch_off(void) {
             ad->power.state = ACPI_STATE_D0;
         }
     } while (0);
+#endif
     pci_set_power_state(dis_dev, PCI_D3cold);
 
     if (bbswitch_acpi_off())


### PR DESCRIPTION
In bbswitch_off() we use acpi_bus_get_device() to determine the power
state, but this feature is only available on x86 and arm64, so make sure
to do this check only on the relevant architectures to prevent build
errors.

Fixes: 5593d95 ("Linux 3.8 compatibility hack")
Signed-off-by: Andrea Righi <andrea.righi@canonical.com>