### PR TITLE
check for power state only when ACPI is available

### DIFF
--- a/bbswitch.c
+++ b/bbswitch.c
@@ -262,6 +262,7 @@ static void bbswitch_off(void) {
     pci_save_state(dis_dev);
     pci_clear_master(dis_dev);
     pci_disable_device(dis_dev);
+#ifdef CONFIG_ACPI
     do {
         struct acpi_device *ad = NULL;
         int r;
@@ -276,6 +277,7 @@ static void bbswitch_off(void) {
             ad->power.state = ACPI_STATE_D0;
         }
     } while (0);
+#endif
     pci_set_power_state(dis_dev, PCI_D3cold);
 
     if (bbswitch_acpi_off())


### PR DESCRIPTION
In bbswitch_off() we use acpi_bus_get_device() to determine the power
state, but this feature is only available if ACPI is enabled in the
kernel, so make sure to do this check only when ACPI is available.

Fixes: 5593d95 ("Linux 3.8 compatibility hack")
Signed-off-by: Dimitri John Ledkov <dimitri.ledkov@canonical.com>
Signed-off-by: Andrea Righi <andrea.righi@canonical.com>